### PR TITLE
squarify 0.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true # [py>=36]
+  skip: true # [py<=36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,20 @@ source:
   sha256: 54091f6ad175f7f201f8934574e647ce1b50dedc478c5fd968688eb7d7469f95
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true # [py>=36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=2.6,<=2.7|>=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=2.6,<=2.7|>=3.5
+    - python
+    # Note this isn't explicitly called out in setup.py but matplotlib is imported
+    # https://github.com/laserson/squarify/blob/42e332c9c69146fcb3bda44c1d3cc3009955327c/squarify/__init__.py#L222
     - matplotlib-base
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,10 @@ requirements:
 test:
   imports:
     - squarify
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/laserson/squarify


### PR DESCRIPTION
squarify 0.4.3

**Destination channel:** main

### Links

- [PKG-4859](https://anaconda.atlassian.net/browse/PKG-4859) 
- [Upstream repository](https://github.com/laserson/squarify)

### Explanation of changes:

- First main build
- Standardized install line
- Added note about matplotlib-base


[PKG-4859]: https://anaconda.atlassian.net/browse/PKG-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ